### PR TITLE
Fix reports percent calculations

### DIFF
--- a/app/admin/collects_reports.rb
+++ b/app/admin/collects_reports.rb
@@ -45,7 +45,7 @@ ActiveAdmin.register_page "Gerencial por rede" do
 
               td { report[:submitted_count] }
 
-              td { b calculate_submitted_percent(summary_counts[:sample_total], report[:submitted_count]) }
+              td { b calculate_submitted_percent(report[:total_sample_count], report[:submitted_count]) }
             end
           end
         end

--- a/app/admin/collects_reports.rb
+++ b/app/admin/collects_reports.rb
@@ -28,6 +28,7 @@ ActiveAdmin.register_page "Gerencial por rede" do
           submissions_reports.group_by(&:adm_cod).each do |(adm_cod, _)|
             submission_report = SubmissionsReport.where(adm_cod: adm_cod)
             report = submission_report.summary
+            substitutes_count = submission_report.first.substitutes_count
             tr do
               td { report[:administration_name] }
 
@@ -37,7 +38,7 @@ ActiveAdmin.register_page "Gerencial por rede" do
 
               td { report[:quitters_count] }
 
-              td { submission_report.first.substitutes_count }
+              td { substitutes_count }
 
               td { report[:redirected_count] }
 
@@ -45,7 +46,7 @@ ActiveAdmin.register_page "Gerencial por rede" do
 
               td { report[:submitted_count] }
 
-              td { b calculate_submitted_percent(report[:total_sample_count], report[:submitted_count]) }
+              td { b calculate_submitted_percent((report[:total_sample_count] - report[:quitters_count] + substitutes_count), report[:submitted_count]) }
             end
           end
         end

--- a/app/admin/sample_report.rb
+++ b/app/admin/sample_report.rb
@@ -42,7 +42,7 @@ ActiveAdmin.register_page "Gerencial por rede (apenas escolas da amostra)" do
 
               td { report.submitted_count }
 
-              td { b calculate_submitted_percent(summary_counts[:sample_total], report.submitted_count) }
+              td { b calculate_submitted_percent(report.sample_count, report.submitted_count) }
             end
           end
         end

--- a/app/admin/sample_report.rb
+++ b/app/admin/sample_report.rb
@@ -42,7 +42,7 @@ ActiveAdmin.register_page "Gerencial por rede (apenas escolas da amostra)" do
 
               td { report.submitted_count }
 
-              td { b calculate_submitted_percent(report.sample_count, report.submitted_count) }
+              td { b calculate_submitted_percent((report.sample_count - report.quitters_count + report.substitutes_count), report.submitted_count) }
             end
           end
         end


### PR DESCRIPTION
O cálculo das porcentagens estava com um parâmetro errado, estava mandando a contagem de respostas do sumário no lugar da rede de ensino, essa mudança corrige este erro.

Antes
![screen shot 2018-07-02 at 09 34 04](https://user-images.githubusercontent.com/554507/42164061-2f39f7f2-7ddb-11e8-94f4-4c1a1e25c1b0.png)
![screen shot 2018-07-02 at 09 33 42](https://user-images.githubusercontent.com/554507/42164068-3258dd5e-7ddb-11e8-8b19-9bbab5ffe6c5.png)

Depois
![screen shot 2018-07-02 at 09 44 02](https://user-images.githubusercontent.com/554507/42164470-7fbb94be-7ddc-11e8-991b-8ef1b37a9c24.png)
![screen shot 2018-07-02 at 09 44 11](https://user-images.githubusercontent.com/554507/42164473-8178c470-7ddc-11e8-916c-874e82434799.png)


Por favor confirmar os números no print antes do merge.
