### PR TITLE
Improve Submissions report

### DIFF
--- a/app/admin/collects_reports.rb
+++ b/app/admin/collects_reports.rb
@@ -70,8 +70,7 @@ ActiveAdmin.register_page "Gerencial por rede" do
           td { h4 b "#{summary_counts.submitted_count}" }
 
           td do
-            schools_total = summary_counts.total_schools_count - summary_counts.quitters_count + summary_counts.substitutes_count
-            h4 b "#{calculate_submitted_percent(schools_total, summary_counts.submitted_count)}"
+            h4 b "#{calculate_submitted_percent(summary_counts.total_schools_count, summary_counts.submitted_count)}"
           end
         end
       end

--- a/app/admin/collects_reports.rb
+++ b/app/admin/collects_reports.rb
@@ -6,7 +6,6 @@ ActiveAdmin.register_page "Gerencial por rede" do
     Collect.all.group_by(&:name).each do |(collect_name, collect_groups)|
       submissions_reports = SubmissionsReport.where(collect_id: collect_groups.map(&:id))
       summary_counts = submissions_reports.summary
-      submission_report = ""
 
       h3 i collect_name
       table do
@@ -25,28 +24,25 @@ ActiveAdmin.register_page "Gerencial por rede" do
         end
 
         tbody do
-          submissions_reports.group_by(&:adm_cod).each do |(adm_cod, _)|
-            submission_report = SubmissionsReport.where(adm_cod: adm_cod)
-            report = submission_report.summary
-            substitutes_count = submission_report.first.substitutes_count
+          submissions_reports.each do |report|
             tr do
-              td { report[:administration_name] }
+              td { report.adm_name }
 
-              td { report[:administration_contact_name] }
+              td { report.adm_contact }
 
-              td { report[:total_sample_count] }
+              td { "#{report.total_schools_count} (#{report.sample_count} na amostra)" }
 
-              td { report[:quitters_count] }
+              td { "#{report.quitters_count} (#{report.quitters_in_sample_count} na amostra)" }
 
-              td { substitutes_count }
+              td { report.substitutes_count }
 
-              td { report[:redirected_count] }
+              td { "#{report.redirected_count} (#{report.redirected_in_sample_count} na amostra)" }
 
-              td { report[:in_progress_count] }
+              td { "#{report.in_progress_count} (#{report.in_progress_in_sample_count} na amostra)" }
 
-              td { report[:submitted_count] }
+              td { "#{report.submitted_count} (#{report.answered_count} na amostra)" }
 
-              td { b calculate_submitted_percent((report[:total_sample_count] - report[:quitters_count] + substitutes_count), report[:submitted_count]) }
+              td { "#{report.total_percent}%" }
             end
           end
         end
@@ -57,25 +53,25 @@ ActiveAdmin.register_page "Gerencial por rede" do
 
           td {}
 
-          td { h4 b summary_counts[:total_sample_count] }
+          td { h4 b summary_counts.total_schools_count }
 
-          td { h4 b "#{summary_counts[:quitters_count]} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], summary_counts[:quitters_count])})" }
+          td { h4 b "#{summary_counts.quitters_count} \
+          (#{calculate_submitted_percent(summary_counts.total_schools_count, summary_counts.quitters_count)})" }
 
-          td { h4 b "#{submission_report.first.substitutes_count_from_collect} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], submission_report.first.substitutes_count_from_collect)})" }
+          td { h4 b "#{summary_counts.substitutes_count} \
+          (#{calculate_submitted_percent(summary_counts.total_schools_count, summary_counts.substitutes_count)})" }
 
-          td { h4 b "#{summary_counts[:redirected_count]} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], summary_counts[:redirected_count])})" }
+          td { h4 b "#{summary_counts.redirected_count} \
+          (#{calculate_submitted_percent(summary_counts.total_schools_count, summary_counts.redirected_count)})" }
 
-          td { h4 b "#{summary_counts[:in_progress_count]} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], summary_counts[:in_progress_count])})" }
+          td { h4 b "#{summary_counts.in_progress_count} \
+          (#{calculate_submitted_percent(summary_counts.total_schools_count, summary_counts.in_progress_count)})" }
 
-          td { h4 b "#{summary_counts[:submitted_count]}" }
+          td { h4 b "#{summary_counts.submitted_count}" }
 
           td do
-            schools_total = summary_counts[:total_sample_count] - summary_counts[:quitters_count] + submission_report.first.substitutes_count_from_collect
-            h4 b "#{calculate_submitted_percent(schools_total, summary_counts[:submitted_count])}"
+            schools_total = summary_counts.total_schools_count - summary_counts.quitters_count + summary_counts.substitutes_count
+            h4 b "#{calculate_submitted_percent(schools_total, summary_counts.submitted_count)}"
           end
         end
       end

--- a/app/admin/sample_report.rb
+++ b/app/admin/sample_report.rb
@@ -70,8 +70,7 @@ ActiveAdmin.register_page "Gerencial por rede (apenas escolas da amostra)" do
           td { h4 b "#{summary_counts.answered_count}" }
 
           td do
-            schools_total = summary_counts.sample_count - summary_counts.quitters_in_sample_count + summary_counts.substitutes_count
-            h4 b "#{calculate_submitted_percent(schools_total, summary_counts.answered_count)}"
+            h4 b " #{calculate_submitted_percent(summary_counts.sample_count, summary_counts.answered_count)}"
           end
         end
       end

--- a/app/admin/sample_report.rb
+++ b/app/admin/sample_report.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register_page "Gerencial por rede (apenas escolas da amostra)" do
     SubmissionsReport.refresh
     h2 "População: amostra"
     Collect.all.group_by(&:name).each do |(collect_name, collect_groups)|
-      submissions_reports = SubmissionsReport.sample.where(collect_id: collect_groups.map(&:id))
+      submissions_reports = SubmissionsReport.where(collect_id: collect_groups.map(&:id))
       summary_counts = submissions_reports.summary
 
       h3 i collect_name
@@ -26,23 +26,23 @@ ActiveAdmin.register_page "Gerencial por rede (apenas escolas da amostra)" do
         tbody do
           submissions_reports.each do |report|
             tr do
-              td { report.administration_name }
+              td { report.adm_name }
 
-              td { report.administration_contact_name }
+              td { report.adm_contact }
 
               td { report.sample_count }
 
-              td { report.quitters_count }
+              td { report.quitters_in_sample_count }
 
               td { report.substitutes_count }
 
-              td { report.redirected_count }
+              td { report.redirected_in_sample_count }
 
-              td { report.in_progress_count }
+              td { report.in_progress_in_sample_count }
 
-              td { report.submitted_count }
+              td { report.answered_count }
 
-              td { b calculate_submitted_percent((report.sample_count - report.quitters_count + report.substitutes_count), report.submitted_count) }
+              td { report.sample_percent }
             end
           end
         end
@@ -53,25 +53,25 @@ ActiveAdmin.register_page "Gerencial por rede (apenas escolas da amostra)" do
 
           td {}
 
-          td { h4 b summary_counts[:total_sample_count] }
+          td { h4 b summary_counts.sample_count }
 
-          td { h4 b "#{summary_counts[:quitters_count]} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], summary_counts[:quitters_count])})" }
+          td { h4 b "#{summary_counts.quitters_in_sample_count} \
+          (#{calculate_submitted_percent(summary_counts.sample_count, summary_counts.quitters_in_sample_count)})" }
 
-          td { h4 b "#{summary_counts[:substitutes_count]} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], summary_counts[:substitutes_count])})" }
+          td { h4 b "#{summary_counts.substitutes_count} \
+          (#{calculate_submitted_percent(summary_counts.sample_count, summary_counts.substitutes_count)})" }
 
-          td { h4 b "#{summary_counts[:redirected_count]} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], summary_counts[:redirected_count])})" }
+          td { h4 b "#{summary_counts.redirected_in_sample_count} \
+          (#{calculate_submitted_percent(summary_counts.sample_count, summary_counts.redirected_in_sample_count)})" }
 
-          td { h4 b "#{summary_counts[:in_progress_count]} \
-          (#{calculate_submitted_percent(summary_counts[:total_sample_count], summary_counts[:in_progress_count])})" }
+          td { h4 b "#{summary_counts.in_progress_in_sample_count} \
+          (#{calculate_submitted_percent(summary_counts.sample_count, summary_counts.in_progress_in_sample_count)})" }
 
-          td { h4 b "#{summary_counts[:submitted_count]}" }
+          td { h4 b "#{summary_counts.answered_count}" }
 
           td do
-            schools_total = summary_counts[:total_sample_count] - summary_counts[:quitters_count] + summary_counts[:substitutes_count]
-            h4 b "#{calculate_submitted_percent(schools_total, summary_counts[:submitted_count])}"
+            schools_total = summary_counts.sample_count - summary_counts.quitters_in_sample_count + summary_counts.substitutes_count
+            h4 b "#{calculate_submitted_percent(schools_total, summary_counts.answered_count)}"
           end
         end
       end

--- a/app/models/submissions_report.rb
+++ b/app/models/submissions_report.rb
@@ -2,48 +2,31 @@ class SubmissionsReport < ApplicationRecord
   belongs_to :collect
   belongs_to :administration
 
-  enum collect_entries_group: { recapture: 0, sample: 1 }
+  scope :summarize, -> {
+    select(*
+      [
+        :total_schools_count,
+        :sample_count,
+        :quitters_count,
+        :quitters_in_sample_count,
+        :substitutes_count,
+        :redirected_count,
+        :redirected_in_sample_count,
+        :in_progress_count,
+        :in_progress_in_sample_count,
+        :submitted_count,
+        :answered_count,
+        :submitted_in_sample_count
+      ].map{ |field| "sum(#{field}::integer) as #{field}" }
+    )
+  }
 
   def readonly?
     true
   end
 
-  def collect_entries
-    CollectEntry.where(adm_cod: adm_cod, collect_id: collect_id)
-  end
-
-  def substitutes_count
-    collect_entries.substitutes.count
-  end
-
-
-  def substitutes_count_from_collect
-    CollectEntry.where(collect_id: collect_id).substitutes.count
-  end
-
   def self.summary
-    initial_counts = {
-      total_sample_count: 0,
-      redirected_count: 0,
-      in_progress_count: 0,
-      submitted_count: 0,
-      quitters_count: 0,
-      substitutes_count: 0,
-      administration_name: "",
-      administration_contact_name: ""
-    }
-
-    self.all.each_with_object(initial_counts) do |report, summary|
-      summary[:quitters_count] += report.quitters_count
-      summary[:substitutes_count] += report.substitutes_count
-      summary[:total_sample_count] += report.sample_count
-      summary[:redirected_count] += report.redirected_count
-      summary[:in_progress_count] += report.in_progress_count
-      summary[:submitted_count] += report.submitted_count
-      summary[:sample_total] = report.sample_count - report.quitters_count + report.substitutes_count
-      summary[:administration_name] = report.administration_name
-      summary[:administration_contact_name] = report.administration_contact_name
-    end
+    summarize.first
   end
 
   def self.refresh

--- a/db/migrate/20180704120845_update_submissions_reports_to_version_2.rb
+++ b/db/migrate/20180704120845_update_submissions_reports_to_version_2.rb
@@ -1,0 +1,8 @@
+class UpdateSubmissionsReportsToVersion2 < ActiveRecord::Migration[5.1]
+  def change
+    update_view :submissions_reports,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+  end
+end

--- a/db/views/submissions_reports_v02.sql
+++ b/db/views/submissions_reports_v02.sql
@@ -1,0 +1,55 @@
+select
+
+adm_cod,
+max(collect_id) as collect_id,
+max(administration_name) as adm_name,
+max(administration_contact_name) as adm_contact,
+sum(sample_count::integer) as total_schools_count,
+sum((case when collect_entries_group = 1 then sample_count else 0 end)::integer) as sample_count,
+sum(quitter_count::integer) as quitters_count,
+sum((case when collect_entries_group = 1 then quitter_count else 0 end)::integer) as quitters_in_sample_count,
+sum(substitute_count::integer) as substitutes_count,
+sum(redirected_count::integer) as redirected_count,
+sum((case when collect_entries_group = 1 then redirected_count else 0 end)::integer) as redirected_in_sample_count,
+sum(in_progress_count::integer) as in_progress_count,
+sum((case when collect_entries_group = 1 then in_progress_count else 0 end)::integer) as in_progress_in_sample_count,
+sum(submitted_count::integer) as submitted_count,
+sum((case when collect_entries_group = 1 then submitted_count else 0 end)::integer) as submitted_in_sample_count,
+sum(answered_count::integer) as answered_count,
+round(sum(answered_count) * 100.0 / sum(case when collect_entries_group = 1 then sample_count else 0 end), 2) as sample_percent,
+round(sum(submitted_count) * 100.0 / sum(sample_count), 2) as total_percent
+from ( select
+t1.adm_cod,
+t1.group as collect_entries_group,
+MAX (t1.collect_id) as collect_id,
+MAX (administration_name) as administration_name,
+MAX (administration_contact_name) as administration_contact_name,
+COUNT (*) as sample_count,
+sum (quitters) as quitter_count,
+SUM (CASE WHEN max_status = 0 THEN 1 ELSE 0 END) as redirected_count,
+SUM (CASE WHEN max_status = 1 THEN 1 ELSE 0 END) as in_progress_count,
+SUM (CASE WHEN max_status = 2 THEN 1 ELSE 0 END) as submitted_count,
+sum (substitutes) as substitute_count,
+sum (answered) as answered_count
+from (
+    select
+      collect_entries.collect_id,
+      collect_entries.school_inep as school_inep,
+      MAX (submissions.status) as max_status,
+      MAX (administrations.name) as administration_name,
+      MAX (administrations.contact_name) as administration_contact_name,
+      MAX (collect_entries.adm_cod) as adm_cod,
+	  MAX (case when collect_entries.substitute then 1 else 0 end) as substitutes,
+	  MAX (case when submissions.status = 2 and not collect_entries.quitter and (collect_entries.group = 1 or (collect_entries.group = 0 and collect_entries.substitute)) then 1 else 0 end) as answered,
+	  MAX (case when collect_entries.quitter then 1 else 0 end) as quitters,
+      collect_entries.group
+    from collect_entries
+    left join submissions on collect_entries.school_inep = submissions.school_inep
+    left join administrations on collect_entries.adm_cod = administrations.cod
+    group by collect_entries.collect_id, collect_entries.school_inep, collect_entries.group
+) as t1
+group by t1.adm_cod, t1.group
+order by t1.adm_cod
+
+) as matview
+group by adm_cod


### PR DESCRIPTION
Mudanças:
 - Melhoramos a query incluindo um novo cálculo para as submissoes enviadas assim como o cálculo da porcentagem da mesma para ambos os grupos
 - Agrupamos as redes na própria view e incluimos os valores de ambos os grupos em colunas diferentes para não precisar fazer agrupamento no código
 - Colocamos de volta os dados de amostra entre parentesis no relatório geral por rede que tinha sido removido por engano


Nova visualização dos relatórios com as mudanças:
![screen shot 2018-07-04 at 11 00 15](https://user-images.githubusercontent.com/554507/42281286-76d8409c-7f79-11e8-8140-2ea1d401aa48.png)
![screen shot 2018-07-04 at 10 50 19](https://user-images.githubusercontent.com/554507/42280848-404ab3da-7f78-11e8-92fa-635de6c0f83d.png)


PS: Com a nova query para submissoes enviadas nós temos 3 valores diferentes para o contexto da rede de Alagoas, por exemplo.

Os valores são:
```
99 enviadas no total
95 enviadas na amostra
98 enviadas com o novo cálculo
```

Iremos considerar a partir de agora apenas o último valor (98) em ambos os relatórios quando se tratar de submissoes enviadas na amostra, visto que foi o valor desejável que nos foi passado.

**Favor confirmar se o valor desejado é o informado**