### PR TITLE
Refactor pipefy card update flow

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -37,6 +37,16 @@ class Submission < ApplicationRecord
     contacts
   end
 
+  def siblings
+    Submission
+    .where.not(id: id)
+    .where(
+      school_inep: school_inep,
+      collect: collect,
+      collect_entry: collect_entry
+    )
+  end
+
   def to_s
     "#{id} #{school_id} - #{status}"
   end

--- a/app/services/pipe_service.rb
+++ b/app/services/pipe_service.rb
@@ -35,4 +35,19 @@ class PipeService
       UpdateCardMemberWorker.perform_async(collect_entry.id)
     end
   end
+
+  def self.first_card_update(collect_entry, pipe, params)
+    PipefyApi.post(pipe.update_card_label(collect_entry.card_id, :redirected))
+    PipefyApi.post(pipe.move_card_to_phase(collect_entry.card_id, :redirected))
+
+    PipefyApi.post(Pipefy::Card.update_school_phone(collect_entry.card_id, params[:school_phone]))
+    PipefyApi.post(Pipefy::Card.update_submitter_name(collect_entry.card_id, params[:submitter_name]))
+    PipefyApi.post(Pipefy::Card.update_submitter_phone(collect_entry.card_id, params[:submitter_phone]))
+    PipefyApi.post(Pipefy::Card.update_submitter_email(collect_entry.card_id, params[:submitter_email]))
+  end
+
+  def self.update_card_to_submitted(submission, pipe)
+    PipefyApi.post(pipe.update_card_label(submission.card_id, :submitted))
+    PipefyApi.post(pipe.move_card_to_phase(submission.card_id, :submitted))
+  end
 end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -1,16 +1,245 @@
 require "rails_helper"
 RSpec.describe SubmissionsController, type: :controller do
-  xdescribe "POST #create" do
-    context "with valid params" do
+  let!(:form) { create(:form) }
+  let!(:administration) { create(:administration) }
+  let!(:pipe) { create(:pipe) }
+  let!(:collect) { create(:collect, administrations: [administration], form: form, pipe: pipe) }
+  let!(:school) { create(:school, adm_cod: administration.cod) }
+  let!(:collect_entry) { create(:collect_entry, collect: collect, school_inep: school.inep, adm_cod: administration.cod) }
+
+  before do
+    allow(PipeService).to receive(:first_card_update).and_return(nil)
+    allow(PipeService).to receive(:update_card_to_submitted).and_return(nil)
+    allow(PipefyApi).to receive(:post).and_return(nil)
+  end
+
+  describe "POST #create" do
+    context "when Submission is new" do
+      let(:params) do
+        {
+          submission: FactoryBot.attributes_for(:submission,
+            collect: collect,
+            collect_entry: collect_entry
+          ).merge(collect_id: collect_entry.collect.id, school_inep: collect_entry.school.inep)
+        }
+      end
+
       it "creates a new Submission" do
         expect {
-          post :create, params: { submission: FactoryBot.attributes_for(:submission) }
+          post :create, params: params
         }.to change(Submission, :count).by(1)
       end
 
-      it "redirects to the created submission" do
-        post :create, params: { submission: FactoryBot.attributes_for(:submission) }
-        expect(response.body).should be_blank
+      it "calls PipeService.first_card_update" do
+        expect(PipeService).to receive(:first_card_update)
+
+        post :create, params: params
+      end
+    end
+
+    context "when the submission is a sibling" do
+      let(:submission) do
+        create(:submission,
+          school_inep: school.inep,
+          collect: collect,
+          collect_entry: collect_entry,
+          adm_cod: administration.cod
+        )
+      end
+
+      let!(:sibling_submission) do
+        create(:submission,
+          school_inep: school.inep,
+          collect: collect,
+          collect_entry: collect_entry,
+          adm_cod: administration.cod
+        )
+      end
+
+      let(:params) do
+        {
+          submission: submission.attributes.merge(
+            collect_id: submission.collect.id,
+            school_inep: submission.school.inep
+          )
+        }
+      end
+
+      it "does not call PipeService#first_card_update" do
+        expect(submission.siblings.any?).to be_truthy
+        expect(PipeService).not_to receive(:first_card_update)
+
+        post :create, params: params
+      end
+
+      it "create a new submission" do
+        expect {
+          post :create, params: params
+        }.to change(Submission, :count)
+      end
+    end
+  end
+
+  describe "POST #update" do
+    context "when the origin submission is missing" do
+      let(:new_school_inep) { "0101" }
+      let!(:another_collect_entry) do
+        create(:collect_entry,
+          collect: collect,
+          school_inep: new_school_inep,
+          adm_cod: administration.cod
+        )
+      end
+      let(:params) do
+        {
+          school_inep: new_school_inep,
+          collect_id: collect.id,
+          form_name: form.name
+        }
+      end
+
+      it "creates a new Submission" do
+        expect {
+          post :update, params: params
+        }.to change(Submission, :count).by(1)
+      end
+
+      context "and status is in_progress" do
+        it "calls Pipefy.post" do
+          expect(PipefyApi).to receive(:post)
+
+          post :update, params: params.merge(status: 'in_progress')
+        end
+      end
+
+      context "and status is submitted" do
+        it "calls PipeService.update_card_to_submitted" do
+          expect(PipeService).to receive(:update_card_to_submitted)
+
+          post :update, params: params.merge(status: 'submitted')
+        end
+      end
+    end
+
+    context "when submission has siblings" do
+      let(:status) { :redirected }
+      let(:fa_status) { :redirected }
+      let!(:submission) do
+        create(:submission,
+          school_inep: school.inep,
+          collect: collect,
+          collect_entry: collect_entry,
+          adm_cod: administration.cod,
+          form_name: form.name,
+          status: status
+        )
+      end
+
+      let!(:sibling_submission) do
+        create(:submission,
+          school_inep: school.inep,
+          collect: collect,
+          collect_entry: collect_entry,
+          adm_cod: administration.cod,
+          form_name: form.name,
+          status: status
+        )
+      end
+
+      let(:params) do
+        params = {
+          school_inep: school.inep,
+          collect_id: collect.id,
+          form_name: form.name,
+          status: fa_status
+        }
+      end
+
+      it "creates another Submission" do
+        expect {
+          post :update, params: params
+        }.to change(Submission, :count).by(1)
+      end
+
+      context "and the max status from siblings is redirected" do
+        it "returns redirected as max status" do
+          expect(submission.siblings.pluck(:status).max).to eq('redirected')
+        end
+
+        context "and the FA param is in_progress" do
+          let(:fa_status) { :in_progress }
+
+          it "updates the card to in_progress" do
+            expect(PipefyApi).to receive(:post)
+
+            post :update, params: params
+          end
+        end
+
+        context "and the FA param is submitted" do
+          let(:fa_status) { :submitted }
+
+          it "updates the card to submitted" do
+            expect(PipeService).to receive(:update_card_to_submitted)
+
+            post :update, params: params
+          end
+        end
+      end
+
+      context "and the max status from siblings is in_progress" do
+        let(:status) { :in_progress }
+        it "returns in_progress as max status" do
+          expect(submission.siblings.pluck(:status).max).to eq('in_progress')
+        end
+
+        context "and the FA param is in_progress" do
+          let(:fa_status) { :in_progress }
+
+          it "does nothing" do
+            expect(PipefyApi).not_to receive(:post)
+            expect(PipeService).not_to receive(:update_card_to_submitted)
+
+            post :update, params: params
+          end
+        end
+
+        context "and the FA param is submitted" do
+          let(:fa_status) { :submitted }
+
+          it "updates the card to submitted" do
+            expect(PipeService).to receive(:update_card_to_submitted)
+
+            post :update, params: params
+          end
+        end
+      end
+
+      context "and the max status from siblings is submitted" do
+        let(:status) { :submitted }
+        it "returns submitted as max status" do
+          expect(submission.siblings.pluck(:status).max).to eq('submitted')
+        end
+
+        context "and the FA param is in_progress" do
+          let(:fa_status) { :in_progress }
+          it "does nothing" do
+            expect(PipefyApi).not_to receive(:post)
+            expect(PipeService).not_to receive(:update_card_to_submitted)
+
+            post :update, params: params
+          end
+        end
+
+        context "and the FA param is submitted" do
+          let(:fa_status) { :submitted }
+          it "does nothing" do
+            expect(PipefyApi).not_to receive(:post)
+            expect(PipeService).not_to receive(:update_card_to_submitted)
+
+            post :update, params: params
+          end
+        end
       end
     end
   end

--- a/spec/factories/pipefy/pipe.rb
+++ b/spec/factories/pipefy/pipe.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :pipe, class: Pipefy::Pipe do
+    pipefy_id { rand(1..1000) }
+    name { FFaker::Company.name }
+    labels do
+      [
+        "{\"name\"=>\"Substituir esta escola\", \"id\"=>\"1\"}",
+        "{\"name\"=>\"Tentei falar, os contatos estão corretos, mas fui ignorada\", \"id\"=>\"2\"}",
+        "{\"name\"=>\"Questionário iniciado\", \"id\"=>\"3\"}",
+        "{\"name\"=>\"Resposta enviada\", \"id\"=>\"4\"}",
+        "{\"name\"=>\"Questionário salvo\", \"id\"=>\"5\"}",
+        "{\"name\"=>\"Consegui falar, acho que vai dar certo\", \"id\"=>\"6\"}",
+        "{\"name\"=>\"Preciso de outro contato para falar com esta escola\", \"id\"=>\"7\"}"
+      ]
+    end
+    phases do
+      [
+        "{\"name\"=>\"Repescagem\", \"id\"=>\"1\"}",
+        "{\"name\"=>\"Triagem\", \"id\"=>\"2\"}",
+        "{\"name\"=>\"Contato Realizado com Gestor\", \"id\"=>\"3\"}",
+        "{\"name\"=>\"Nenhum Retorno\", \"id\"=>\"4\"}",
+        "{\"name\"=>\"Quest. em progresso\", \"id\"=>\"5\"}",
+        "{\"name\"=>\"Quest. Respondido\", \"id\"=>\"6\"}",
+        "{\"name\"=>\"Desistentes\", \"id\"=>\"7\"}"
+      ]
+    end
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :submission do
-    association :school, factory: :school
     status [:redirected, :in_progress, :submitted].sample
     school_phone "123"
-    submitter_name { FFaker::Internet.name }
+    submitter_name { FFaker::Name.name }
     submitter_email { FFaker::Internet.email }
     submitter_phone "123"
     response_id { rand(1..10) }
@@ -11,7 +10,23 @@ FactoryBot.define do
     saved_at { FFaker::Time.datetime }
     modified_at { FFaker::Time.datetime }
     submitted_at { FFaker::Time.datetime }
-    form_name "baseline"
+    form_name "form name"
     adm_cod "1"
+    card_id { rand(1..10) }
+  end
+
+  trait :redirected do
+    status :redirected
+    redirected_at { DateTime.now }
+  end
+
+  trait :in_progress do
+    status :in_progress
+    saved_at { DateTime.now }
+  end
+
+  trait :submitted do
+    status :submitted
+    submitted_at { DateTime.now }
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -91,4 +91,28 @@ RSpec.describe Submission, type: :model do
       expect(submission.to_s).to eq("#{submission.id} #{submission.school_id} - #{submission.status}")
     end
   end
+
+  describe ".siblings" do
+    context "when there is no siblings" do
+      let(:collect) { create :collect }
+      let(:collect_entry) { create :collect_entry }
+      let(:submission) { create(:submission, school_inep: '1', collect: collect, collect_entry: collect_entry ) }
+      let(:another_submission) { create(:submission, school_inep: '2', collect: collect, collect_entry: collect_entry ) }
+
+      it "returns no siblings for both submissions" do
+        expect(submission.siblings).to be_empty
+        expect(another_submission.siblings).to be_empty
+      end
+    end
+
+    context "when there is siblings" do
+      let(:collect) { create :collect }
+      let(:collect_entry) { create :collect_entry }
+      let(:submissions) { create_list(:submission, 2, school_inep: '1', collect: collect, collect_entry: collect_entry ) }
+
+      it "returns the sibling" do
+        expect(submissions.first.siblings).to eq([submissions.last])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Mudanças para resolver os problemas reportados abaixo após a mudança na lógica de novas submissões

- _Se, depois de enviado a mesma escola iniciar novamente o questionário, devemos ignorar pois ela já respondeu o questionário. [X]_

- _Se a escola já salvou o questionário, não devemos voltar para o status iniciado, ou seja, é sempre considerado o status mais avançado (a mesma lógica dos relatórios) [X] _

_Como funciona hoje:_
- _Ele atualiza o status para o mais recente, ou seja, se a escola enviou o questionário e alguém inicia novamente, ela volta para a fase "Questionário em Progresso" com o label "Questionário Iniciado", desconsiderando o status mais avançado._


**As mudanças precisam ser testadas em staging com o pipe template que contém todos os campos das escolas**