### PR TITLE
Add translated terms to CollectEntry#group

### DIFF
--- a/app/models/collect_entry.rb
+++ b/app/models/collect_entry.rb
@@ -6,7 +6,7 @@ class CollectEntry < ApplicationRecord
 
   scope :substitutes, -> { where substitute: true }
 
-  enum group: { recapture: 0, sample: 1 }
+  enum group: { recapture: 0, Repescagem: 0, sample: 1, Amostra: 1 }
 
   def self.groups_for_filter
     collection ||= groups.collect { |k, v| [CollectEntry.human_attribute_name(k), v] }

--- a/spec/models/collect_entry_spec.rb
+++ b/spec/models/collect_entry_spec.rb
@@ -5,4 +5,24 @@ RSpec.describe CollectEntry, type: :model do
   it { is_expected.to belong_to(:administration) }
   it { is_expected.to belong_to(:school) }
   it { should define_enum_for(:group) }
+
+  describe 'group' do
+    let(:collect_entry) { create(:collect_entry, group: group) }
+
+    context 'Repescagem' do
+      let(:group) { "Repescagem" }
+
+      it "allow Repescagem as a value" do
+        expect(collect_entry.recapture?).to be_truthy
+      end
+    end
+
+    context 'Amostra' do
+      let(:group) { "Amostra" }
+
+      it "allow Amostra as a value" do
+        expect(collect_entry.sample?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
Com a mudança do tipo do `CollectEntry#group` para `Enum` na refatoração dos relatórios, a importação dos Estratos foi afetada.

Essa mudança adiciona os termos `Amostra` e `Repescagem` no enum do CollectEntry#group para aceitar o template de dados vigente sem precisar alterar o modelo de importação existente.