### PR TITLE
Fix CollectEntry groups for ActiveAdmin select and filter

### DIFF
--- a/app/admin/collect_entry.rb
+++ b/app/admin/collect_entry.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register CollectEntry do
   filter :school_inep_cont, label: i18n_for("collect_entry", "inep")
   filter :collect, label: i18n_for("collect_entry", "collect_id"),
     as: :select, collection: proc { Collect.all }
-  filter :group, label: "", as: :check_boxes, collection: CollectEntry.groups_for_filter
+  filter :group, label: "", as: :check_boxes, collection: { "Amostra": 1, "Repescagem": 0 }
 
   index do
     column :id
@@ -51,7 +51,7 @@ ActiveAdmin.register CollectEntry do
       input :sample_size
       input :school_inep, as: :string
       input :school_sequence
-      input :group
+      input :group, collection: ["Amostra", "Repescagem"]
       input :collect
       input :card_id
       input :member_email


### PR DESCRIPTION
Com a adição do código para aceitar os termos em português na importação dos estratos, ficamos com opções duplicadas.

Essa correção remove as opções indesejadas.

![screen shot 2018-11-08 at 14 09 05](https://user-images.githubusercontent.com/554507/48215066-2a3ff400-e360-11e8-9b41-b446bd179736.png)
![screen shot 2018-11-08 at 14 09 14](https://user-images.githubusercontent.com/554507/48215067-2a3ff400-e360-11e8-97a7-2a49a3dea265.png)
